### PR TITLE
Update NVE flood source and API routing

### DIFF
--- a/main_files/chat.js
+++ b/main_files/chat.js
@@ -218,7 +218,7 @@ document.addEventListener('DOMContentLoaded', function() {
         
         try {
             // Connect to our proxy endpoint instead of directly to OpenRouter
-            const response = await fetch('/api/chat', {
+            const response = await fetch(`${API_BASE}/chat`, {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json'

--- a/main_files/mapoverlay.js
+++ b/main_files/mapoverlay.js
@@ -8,6 +8,9 @@ let map;
 let searchMarkers;
 let floodZoneLayer; // Legger til variabel for flomsoner
 
+// Shared API base: works whether page is served by Express (port 5000) or Live Server (port 5500)
+const API_BASE = (location.port === '5000' || location.port === '') ? '/api' : 'http://localhost:5000/api';
+
 // Initialiser når DOM er lastet
 document.addEventListener('DOMContentLoaded', function () {
     initializeMap();
@@ -95,14 +98,12 @@ function initializeMap() {
     }).addTo(map);
 
 
-    // Oppretter flomsonelag fra NVE WMS-tjeneste
-    const floodZoneLayer = L.tileLayer.wms("https://nve.geodataonline.no/arcgis/services/FlomAktsomhet/MapServer/WmsServer", {
-        layers: "Flom_aktsomhetsomrade",
-        styles: "",
-        format: "image/png",
-        transparent: true,
-        crs: L.CRS.EPSG3857, // Leaflet bruker EPSG:3857
-        attribution: "Kartdata: © NVE"
+    // Flomsonelag via server-proxy (NVE gis3.nve.no Flomsoner2)
+    const floodTileBase = API_BASE.replace('/api', '');
+    const floodZoneLayer = L.tileLayer(floodTileBase + '/api/flood-tiles/{z}/{x}/{y}.png', {
+        opacity: 0.6,
+        attribution: "Flomsoner: © NVE",
+        maxZoom: 18
     });
 
     // Sett floodZoneLayer globalt tilgjengelig

--- a/main_files/script.js
+++ b/main_files/script.js
@@ -154,7 +154,7 @@ async function loadEmergencyData() {
 // Hent tilfluktsromdata fra backend
 async function fetchShelterData() {
     try {
-        const response = await fetch("/api/tilfluktsrom_agder");
+        const response = await fetch(`${API_BASE}/tilfluktsrom_agder`);
 
         if (!response.ok) {
             throw new Error(`Kunne ikke hente tilfluktsromdata: ${response.status}`);
@@ -175,7 +175,7 @@ async function fetchShelterData() {
 // Hent brannstasjonsdata fra backend
 async function fetchFireStationData() {
     try {
-        const response = await fetch("/api/brannstasjoner_agder");
+        const response = await fetch(`${API_BASE}/brannstasjoner_agder`);
 
         if (!response.ok) {
             throw new Error(`Kunne ikke hente brannstasjonsdata: ${response.status}`);

--- a/main_files/ui.js
+++ b/main_files/ui.js
@@ -3,7 +3,7 @@
  * Håndterer alle UI-interaksjoner, animasjoner og tilstandshåndtering
  */
 
-const API_BASE = '/api';
+// API_BASE is defined globally in mapoverlay.js (loaded first)
 
 document.addEventListener('DOMContentLoaded', function () {
     // Initialiser systemtilstand

--- a/server.js
+++ b/server.js
@@ -139,15 +139,16 @@ app.get('/api/weather', async (req, res) => {
     }
   });
 
-// 2) Flomvarsel (NVE WMS GetFeatureInfo)
+// 2) Flomvarsel NVE Flomsoner2
 app.get('/api/flood', async (req, res) => {
     const { lat, lon } = req.query;
     if (!lat || !lon) {
       return res.status(400).json({ error: 'Mangler lat eller lon' });
     }
   
+    // Layer 5 = Flomsone_100arsflom
     const url =
-      `https://nve.geodataonline.no/arcgis/rest/services/FlomAktsomhet/MapServer/0/query` +
+      `https://gis3.nve.no/arcgis/rest/services/wmts/Flomsoner2/MapServer/5/query` +
       `?geometry=${lon},${lat}` +
       `&geometryType=esriGeometryPoint` +
       `&inSR=4326&outFields=*&outSR=4326&f=json`;
@@ -166,5 +167,51 @@ app.get('/api/flood', async (req, res) => {
     }
   });
 
+// 3) NVE flomsone-fliser — proxy for ArcGIS export (erstatter den tidligere nve.geodataonline.no WMS)
+app.get('/api/flood-tiles/:z/:x/:y.png', async (req, res) => {
+    const { z, x, y } = req.params;
+    const zi = parseInt(z), xi = parseInt(x), yi = parseInt(y);
 
-app.listen(PORT, () => console.log(`Server running on port ${PORT}`));
+    // Convert tile coords (z/x/y) to EPSG:3857 bbox
+    function tileToMercator(z, x, y) {
+        const size = 20037508.342789244 * 2;
+        const tileSize = size / Math.pow(2, z);
+        return [
+            -20037508.342789244 + x * tileSize,
+            20037508.342789244 - (y + 1) * tileSize,
+            -20037508.342789244 + (x + 1) * tileSize,
+            20037508.342789244 - y * tileSize
+        ];
+    }
+
+    const [xmin, ymin, xmax, ymax] = tileToMercator(zi, xi, yi);
+    // Viser lagene 4–10 (50 år - 1000 år flomsoner)
+    const url =
+        `https://gis3.nve.no/arcgis/rest/services/wmts/Flomsoner2/MapServer/export` +
+        `?bbox=${xmin},${ymin},${xmax},${ymax}` +
+        `&bboxSR=3857&layers=show:4,5,6,7,8,9,10&size=256,256&imageSR=3857&format=png32&transparent=true&f=image`;
+
+    try {
+        const r = await fetch(url);
+        if (!r.ok) throw new Error(`NVE tile HTTP ${r.status}`);
+        const buf = await r.arrayBuffer();
+        res.setHeader('Content-Type', 'image/png');
+        res.setHeader('Cache-Control', 'public, max-age=3600');
+        res.send(Buffer.from(buf));
+    } catch (err) {
+        console.error('Flood tile error:', err.message);
+        res.status(502).end();
+    }
+});
+
+
+const server = app.listen(PORT, () => console.log(`Server running on port ${PORT}`));
+
+server.on('error', (err) => {
+    if (err.code === 'EADDRINUSE') {
+        console.error(`\nPort ${PORT} is already in use.\nKill the existing process first:\n  Get-Process node | Stop-Process\nthen run 'npm start' again.\n`);
+    } else {
+        console.error('Server error:', err.message);
+    }
+    process.exit(1);
+});


### PR DESCRIPTION
- Fix NVE flood endpoints: migrate from dead host (nve.geodataonline.no) to gis3.nve.no/arcgis/rest/services/wmts/Flomsoner2; replace broken WMS layer with /api/flood-tiles/:z/:x/:y.png proxy that converts tile coords to ArcGIS export bbox